### PR TITLE
Test for scale equality differently

### DIFF
--- a/tests/testthat/test-scale_hdx.R
+++ b/tests/testthat/test-scale_hdx.R
@@ -1,27 +1,37 @@
 test_that("scale_colour matches scale_color", {
+  # Scale are environments with gnarly parentage.
+  # Convert these to lists to test for equality in a more straightforward
+  # manner
+  expect_equal_scale <- function(x, y, ...) {
+    x <- as.list(x)
+    y <- as.list(y)
+    x$call <- y$call <- NULL
+    expect_equal(x, y, ...)
+  }
+
   # discrete color scales
-  expect_equal(scale_color_hdx_discrete(), scale_colour_hdx_discrete())
-  expect_equal(scale_color_hdx_mint(), scale_colour_hdx_mint())
-  expect_equal(scale_color_hdx_tomato(), scale_colour_hdx_tomato())
-  expect_equal(scale_color_hdx_sapphire(), scale_colour_hdx_sapphire())
+  expect_equal_scale(scale_color_hdx_discrete(), scale_colour_hdx_discrete())
+  expect_equal_scale(scale_color_hdx_mint(), scale_colour_hdx_mint())
+  expect_equal_scale(scale_color_hdx_tomato(), scale_colour_hdx_tomato())
+  expect_equal_scale(scale_color_hdx_sapphire(), scale_colour_hdx_sapphire())
 
   # continuous color scales
-  expect_equal(scale_color_gradient_hdx(), scale_colour_gradient_hdx())
-  expect_equal(
+  expect_equal_scale(scale_color_gradient_hdx(), scale_colour_gradient_hdx())
+  expect_equal_scale(
     scale_color_gradient_hdx_mint(),
     scale_colour_gradient_hdx_mint()
   )
-  expect_equal(
+  expect_equal_scale(
     scale_color_gradient_hdx_tomato(),
     scale_colour_gradient_hdx_tomato()
   )
-  expect_equal(
+  expect_equal_scale(
     scale_color_gradient_hdx_sapphire(),
     scale_colour_gradient_hdx_sapphire()
   )
 
   # 2 gradient scale
-  expect_equal(
+  expect_equal_scale(
     scale_color_gradient2_hdx(),
     scale_colour_gradient2_hdx()
   )


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break gghdx.

Briefly, we've updated the `call` fields in scales to more accurately report the offending scale in error messages and warnings. This updates breaks the equality of scales in gghdx. This PR updates tests to ignore the `call` field and test for list-equality.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help gghdx get out a fix if necessary.